### PR TITLE
Used normalmatrix instead of modelmatrix

### DIFF
--- a/Shaders/StaticModel.vert
+++ b/Shaders/StaticModel.vert
@@ -23,8 +23,10 @@ void main()
 	gl_Position = projMatrix * viewMatrix * world_position;
 
 	vec3 diffuse;
-
-	vec3 surfaceNormal   = (modelMatrix * vec4(inNormal, 0.0)).xyz;
+	
+	mat4 normalMatrix = inverse(transpose(viewMatrix * modelMatrix)); 
+	
+	vec3 surfaceNormal   = (normalMatrix * vec4(inNormal, 0.0)).xyz;
 	vec3 unitNormal      = normalize(surfaceNormal);
 
 	vec3 toCameraVector  = (inverse(viewMatrix) * vec4(0.0, 0.0, 0.0, 1.0)).xyz - world_position.xyz;


### PR DESCRIPTION
Using model matrix is fine if your modelView matrix is orthogonal. But, any moment your modelView matrix is not orthogonal your normal will be incorrect. It is preferred to calculate this matrix outside of the shader though, so look at this only as a temporary solution.